### PR TITLE
solve lint error

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,7 +32,11 @@ export default [
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },
-      ],
+        ],
+        'no-unused-vars': [
+            'error',
+            { "varsIgnorePattern": '^React$' }
+        ],
     },
   },
 ]


### PR DESCRIPTION
## Related Issue 
Solves issue #37.

---

## Description
I have updated the eslint.config.js file to ignore the React variable when it is imported but not explicitly used. This resolves the ESLint warnings about unused variables in files that use JSX.

---

## Checklist
Please ensure the following before submitting the PR:
- [x] I have read the `CODE_OF_CONDUCT.md` file and followed it's guidelines.
- [ ] I have followed the design specified in the Figma file (if applicable).

## Key takeaways
- Before React 17: It was necessary to include the line " import React from 'react' " because JSX tags were compiled into React.createElement() calls, requiring the explicit React import.
- After React 17: Importing React explicitly is no longer required, as the JSX compiler automatically handles this during compilation.
