### PR TITLE
Added past events header

### DIFF
--- a/src/components/PastEventsHeader/PastEventsHeader.css
+++ b/src/components/PastEventsHeader/PastEventsHeader.css
@@ -1,0 +1,37 @@
+.past-events-header {
+    background-color: #ffffff;
+    padding: 1rem;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  }
+  
+  .header-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  
+  .back-button {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #666;
+    text-decoration: none;
+    transition: color 0.3s ease;
+  }
+  
+  .back-button:hover {
+    color: #333;
+  }
+  
+  .back-button svg {
+    width: 24px;
+    height: 24px;
+  }
+  
+  .header-title {
+    font-size: 1.5rem;
+    color: #222;
+    margin: 0;
+  }

--- a/src/components/PastEventsHeader/PastEventsHeader.css
+++ b/src/components/PastEventsHeader/PastEventsHeader.css
@@ -1,37 +1,40 @@
 .past-events-header {
-    background-color: #ffffff;
-    padding: 1rem;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-  }
-  
-  .header-content {
-    max-width: 1200px;
-    margin: 0 auto;
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-  }
-  
-  .back-button {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    color: #666;
-    text-decoration: none;
-    transition: color 0.3s ease;
-  }
-  
-  .back-button:hover {
-    color: #333;
-  }
-  
-  .back-button svg {
-    width: 24px;
-    height: 24px;
-  }
-  
-  .header-title {
-    font-size: 1.5rem;
-    color: #222;
-    margin: 0;
-  }
+  position: relative;
+  width: 100%;
+  height: 300px;
+  background-size: cover;
+  background-position: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgb(28, 9, 95);
+}
+
+.back-link {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+}
+
+.back-button {
+  color: rgb(88, 198, 250);
+  text-decoration: none;
+  font-size: 16px; 
+  font-family: Arial;
+}
+
+.title-container {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  border: 2px solid rgb(88, 198, 250);
+  width: 50%;
+  padding: 50px;
+}
+
+.header-title {
+  color: rgb(88, 198, 250);
+  font-size: 36px;
+  margin: 0;
+  font-family: Inter;
+}

--- a/src/components/PastEventsHeader/PastEventsHeader.jsx
+++ b/src/components/PastEventsHeader/PastEventsHeader.jsx
@@ -1,31 +1,14 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import './PastEventsHeader.css';
 
 const PastEventsHeader = () => {
   return (
     <header className="past-events-header">
-      <div className="header-content">
-
-        <Link to="/" className="back-button">
-          <svg 
-            width="24" 
-            height="24" 
-            viewBox="0 0 24 24" 
-            fill="none" 
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path 
-              d="M19 12H5M12 19l-7-7 7-7" 
-              stroke="currentColor" 
-              strokeWidth="2" 
-              strokeLinecap="round" 
-              strokeLinejoin="round"
-            />
-          </svg>
-          <span>Back</span>
-        </Link>
-
-
+      <div className="back-link">
+        <Link to="/" className="back-button">Back</Link>
+      </div>
+      <div className="title-container">
         <h1 className="header-title">PAST EVENTS</h1>
       </div>
     </header>

--- a/src/components/PastEventsHeader/PastEventsHeader.jsx
+++ b/src/components/PastEventsHeader/PastEventsHeader.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import './PastEventsHeader.css';
+
+const PastEventsHeader = () => {
+  return (
+    <header className="past-events-header">
+      <div className="header-content">
+
+        <Link to="/" className="back-button">
+          <svg 
+            width="24" 
+            height="24" 
+            viewBox="0 0 24 24" 
+            fill="none" 
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path 
+              d="M19 12H5M12 19l-7-7 7-7" 
+              stroke="currentColor" 
+              strokeWidth="2" 
+              strokeLinecap="round" 
+              strokeLinejoin="round"
+            />
+          </svg>
+          <span>Back</span>
+        </Link>
+
+
+        <h1 className="header-title">PAST EVENTS</h1>
+      </div>
+    </header>
+  );
+};
+
+export default PastEventsHeader;

--- a/src/pages/PastEvents.jsx
+++ b/src/pages/PastEvents.jsx
@@ -1,12 +1,13 @@
-import React from 'react'
-import PastEventsHeader from 'src/components/PastEventsHeader';
+import React from 'react';
+import PastEventsHeader from '../components/PastEventsHeader/PastEventsHeader';
 
 const PastEvents = () => {
   return (
     <div>
-      
+      <PastEventsHeader />
+
     </div>
   )
 }
 
-export default PastEvents
+export default PastEvents;

--- a/src/pages/PastEvents.jsx
+++ b/src/pages/PastEvents.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PastEventsHeader from 'src/components/PastEventsHeader';
 
 const PastEvents = () => {
   return (


### PR DESCRIPTION
## Related Issue
Resolves #32.

---

## Description
-This PR adds a "Past Events" header **component**
-Imports past events header in ```PastEvets.jsx```
-Styles text alignment, color, and size according to Figma

---

## Demo Past Events Page
<img width="1057" alt="Demo Header Image" src="https://github.com/user-attachments/assets/c49e9e2c-6c72-4edd-a5db-333639381d99" />

---

## Checklist
Please ensure the following before submitting the PR:
- [x] I have read the `CODE_OF_CONDUCT.md` file and followed it's guidlines.
- [x] I have followed the design specified in the Figma file (if applicable).

<!-- You can check the box like this: [x] -->

---

## Additional Comments
**Challenges**
This is one of my first contributions to open-source projects. I struggled running my code locally to test my updates but learned a lot. Thanks for the opportunity.
**Testing**
Ran my code in Chrome and Safari Browser.
**Comments**
In the CSS file of the component, ```past-events-header```can be modified with:
- ```height: 300px;``` change the height of the header accordingly to the page later
- ```background-image: url('');``` add a URL to the actual figma design's background (I couldn’t find the image)
